### PR TITLE
Add option '--lenses' for generation of lenses

### DIFF
--- a/Text/ProtocolBuffers/Reflections.hs
+++ b/Text/ProtocolBuffers/Reflections.hs
@@ -55,6 +55,7 @@ data ProtoFName = ProtoFName { protobufName' :: FIName Utf8     -- ^ fully quali
                              , haskellPrefix' :: [MName String] -- ^ Haskell specific prefix to module hierarchy (e.g. Text.Foo)
                              , parentModule' :: [MName String]  -- ^ .proto specified namespace (like Com.Google.Bar)
                              , baseName' :: FName String
+                             , baseNamePrefix' :: String -- "_" if lenses are generated
                              }
   deriving (Show,Read,Eq,Ord,Data,Typeable)
 
@@ -77,6 +78,7 @@ data DescriptorInfo = DescriptorInfo { descName :: ProtoName
                                      , knownKeys :: Seq FieldInfo
                                      , storeUnknown :: Bool
                                      , lazyFields :: Bool
+                                     , makeLenses :: Bool
                                      }
   deriving (Show,Read,Eq,Ord,Data,Typeable)
 


### PR DESCRIPTION
This prefixes all record field accessors with an underscore and uses 'makeLenses' to generate the lenses using template haskell.

I could make this a bit more configurable: For users with large codebases, it could be a huge effort to change all the record accessor names when switching to lenses. For them it would make sense to have the lenses (instead of the record accessors) prefixed with an underscore, not the other way round.