### PR TITLE
Generate code for services

### DIFF
--- a/Text/ProtocolBuffers.hs
+++ b/Text/ProtocolBuffers.hs
@@ -1,4 +1,4 @@
-{- | 
+{- |
 
 "Text.ProtocolBuffers" exposes the client API.  This merely re-exports parts of the
 other modules in protocol-buffers.  The exposed parts are:
@@ -45,6 +45,7 @@ module Text.ProtocolBuffers(
   , module Text.ProtocolBuffers.Extensions
   , module Text.ProtocolBuffers.Identifiers
   , module Text.ProtocolBuffers.Reflections
+  , module Text.ProtocolBuffers.Services
   , module Text.ProtocolBuffers.TextMessage
   , module Text.ProtocolBuffers.WireMessage
   ) where
@@ -60,6 +61,8 @@ import Text.ProtocolBuffers.Identifiers
 import Text.ProtocolBuffers.Reflections
   ( ReflectDescriptor(..),ReflectEnum(..),ProtoName(..),HsDefault(..),EnumInfoApp
   , KeyInfo,FieldInfo(..),DescriptorInfo(..),EnumInfo(..),ProtoInfo(..),makePNF )
+import Text.ProtocolBuffers.Services
+  (MethodCxt, MethodHandler(..), methodName, reifyMethods)
 import Text.ProtocolBuffers.TextMessage
   ( messagePutText, messageGetText )
 import Text.ProtocolBuffers.WireMessage

--- a/Text/ProtocolBuffers.hs
+++ b/Text/ProtocolBuffers.hs
@@ -62,7 +62,7 @@ import Text.ProtocolBuffers.Reflections
   ( ReflectDescriptor(..),ReflectEnum(..),ProtoName(..),HsDefault(..),EnumInfoApp
   , KeyInfo,FieldInfo(..),DescriptorInfo(..),EnumInfo(..),ProtoInfo(..),makePNF )
 import Text.ProtocolBuffers.Services
-  (MethodCxt, MethodHandler(..), methodName, reifyMethods)
+  (MethodCxt, MethodHandler(..), methodName, serviceName, packageName, reifyMethods)
 import Text.ProtocolBuffers.TextMessage
   ( messagePutText, messageGetText )
 import Text.ProtocolBuffers.WireMessage

--- a/Text/ProtocolBuffers/Basic.hs
+++ b/Text/ProtocolBuffers/Basic.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable,GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveDataTypeable,GeneralizedNewtypeDeriving,DataKinds,KindSignatures,RankNTypes,ScopedTypeVariables #-}
 -- | "Text.ProtocolBuffers.Basic" defines or re-exports most of the
 -- basic field types; 'Maybe','Bool', 'Double', and 'Float' come from
 -- the Prelude instead. This module also defines the 'Mergeable' and
@@ -11,6 +11,7 @@ module Text.ProtocolBuffers.Basic
     -- * Some of the type classes implemented messages and fields
   , Mergeable(..),Default(..) -- ,Wire(..)
   , isValidUTF8, toUtf8, utf8, uToString, uFromString
+  , Service(..), Method(..)
   ) where
 
 import Data.Bits(Bits)
@@ -26,6 +27,9 @@ import Data.Word(Word8,Word32,Word64)
 
 import qualified Data.ByteString.Lazy as L(unpack)
 import Data.ByteString.Lazy.UTF8 as U (toString,fromString)
+
+import GHC.TypeLits  (Symbol)
+
 
 -- Num instances are derived below for the purpose of getting fromInteger for case matching
 
@@ -219,6 +223,13 @@ uToString (Utf8 bs) = U.toString bs
 uFromString :: String -> Utf8
 uFromString s = Utf8 (U.fromString s)
 
+-- | A descriptor for service methods.
+data Method (name :: Symbol) request response = Method
+                                              deriving (Typeable)
+
+-- | A proxy for services.
+data Service (methods :: [*]) = Service
+                              deriving (Typeable)
 
 -- Base types are not very mergeable, but their Maybe and Seq versions are:
 instance Mergeable a => Mergeable (Maybe a) where
@@ -257,4 +268,3 @@ instance Default (Maybe a) where defaultValue = Nothing
 instance Default (Seq a) where defaultValue = mempty
 instance Default ByteString where defaultValue = mempty
 instance Default Utf8 where defaultValue = mempty
-

--- a/Text/ProtocolBuffers/Reflections.hs
+++ b/Text/ProtocolBuffers/Reflections.hs
@@ -14,6 +14,7 @@
 module Text.ProtocolBuffers.Reflections
   ( ProtoName(..),ProtoFName(..),ProtoInfo(..),DescriptorInfo(..),FieldInfo(..),KeyInfo
   , HsDefault(..),SomeRealFloat(..),EnumInfo(..),EnumInfoApp
+  , ServiceInfo(..), MethodInfo(..)
   , ReflectDescriptor(..),ReflectEnum(..),GetMessageInfo(..)
   , OneofInfo(..)
   , makePNF, toRF, fromRF
@@ -44,7 +45,7 @@ makePNF a bs cs d =
 -- from the '.proto' file and any nested levels of definition.
 --
 -- The name components are likely to have been mangled to ensure the
--- 'baseName' started with an uppercase letter, in @ ['A'..'Z'] @.
+-- 'baseName' started with an uppercase letter, in @ [A'..'Z'] @.
 data ProtoName = ProtoName { protobufName :: FIName Utf8     -- ^ fully qualified name using "package" prefix (no mangling)
                            , haskellPrefix :: [MName String] -- ^ Haskell specific prefix to module hierarchy (e.g. Text.Foo)
                            , parentModule :: [MName String]  -- ^ .proto specified namespace (like Com.Google.Bar)
@@ -67,6 +68,7 @@ data ProtoInfo = ProtoInfo { protoMod :: ProtoName        -- ^ blank protobufNam
                            , messages :: [DescriptorInfo] -- ^ all messages and groups
                            , enums :: [EnumInfo]          -- ^ all enums
                            , oneofs :: [OneofInfo]
+                           , services :: [ServiceInfo]    -- ^ all services
                            , knownKeyMap :: Map ProtoName (Seq FieldInfo) -- all keys in namespace
                            }
   deriving (Show,Read,Eq,Ord,Data,Typeable)
@@ -74,7 +76,7 @@ data ProtoInfo = ProtoInfo { protoMod :: ProtoName        -- ^ blank protobufNam
 data DescriptorInfo = DescriptorInfo { descName :: ProtoName
                                      , descFilePath :: [FilePath]
                                      , isGroup :: Bool
-                                     , fields :: Seq FieldInfo
+                                     , fields :: Seq FieldInfo 
                                      , descOneofs :: Seq OneofInfo 
                                      , keys :: Seq KeyInfo
                                      , extRanges :: [(FieldId,FieldId)]
@@ -188,3 +190,15 @@ class ReflectDescriptor m where
                                                   [ wireTag f | f <- F.toList (knownKeys di)]
                                               }
   reflectDescriptorInfo :: m -> DescriptorInfo    -- ^ Must not inspect argument
+
+data ServiceInfo =
+  ServiceInfo { serviceName     :: ProtoName
+              , serviceMethods  :: [MethodInfo]
+              , serviceFilePath :: [FilePath]
+              } deriving (Show,Read,Eq,Ord,Data,Typeable)
+
+data MethodInfo =
+  MethodInfo { methodName   :: ProtoName
+             , methodInput  :: ProtoName
+             , methodOutput :: ProtoName
+             } deriving (Show,Read,Eq,Ord,Data,Typeable)

--- a/Text/ProtocolBuffers/Services.hs
+++ b/Text/ProtocolBuffers/Services.hs
@@ -10,14 +10,20 @@
 module Text.ProtocolBuffers.Services(
     MethodCxt
   , MethodHandler(..)
+
   , methodName
+  , packageName
+  , serviceName
+
   , reifyMethods
   ) where
 
 import           Text.ProtocolBuffers.Basic
-import           Text.ProtocolBuffers.Reflections hiding (methodName)
+import           Text.ProtocolBuffers.Reflections hiding (methodName,
+                                                   serviceName)
 import           Text.ProtocolBuffers.WireMessage
 
+import           Data.List                        (intercalate)
 import           Data.Proxy
 import           GHC.TypeLits
 
@@ -31,13 +37,27 @@ type MethodCxt name req resp = ( ReflectDescriptor req
 
 -- | The name of a method.
 methodName :: forall name req resp . KnownSymbol name => Method name req resp -> String
-methodName _ = symbolVal (Proxy :: Proxy name)
+methodName _ = name
+  where fqn = symbolVal (Proxy :: Proxy name)
+        name = last (split ('.' ==) fqn)
+
+-- | The service name which the method belongs to.
+serviceName :: forall name req resp. KnownSymbol name => Method name req resp -> String
+serviceName _ = name
+  where fqn = symbolVal (Proxy :: Proxy name)
+        name = last (init (split ('.' ==) fqn))
+
+-- | The methods package name.
+packageName :: forall name req resp. KnownSymbol name => Method name req resp -> String
+packageName _ = name
+  where fqn = symbolVal (Proxy :: Proxy name)
+        name =  intercalate "." (drop 1 (init (init (split ('.' ==) fqn))))
 
 -- | A reified method attached with a function to execute the method.
 data MethodHandler m = forall name req resp. MethodCxt name req resp =>
                        MethodHandler (Method name req resp) (req -> m resp)
 
--- |This class can be used to reify a service to value level.
+-- | This class can be used to reify a service to value level.
 class HasMethod (m :: * -> *) (a :: [*]) where
   type MkHandler a m
   reifyMethods :: Service a -> [MethodHandler m] ->  MkHandler a m
@@ -49,3 +69,10 @@ instance HasMethod m '[] where
 instance (HasMethod m rest, MethodCxt name req resp) => HasMethod m (Method name req resp ': rest) where
   type MkHandler (Method name req resp ': rest) m = (req -> m resp) -> MkHandler rest m
   reifyMethods _ hx = \f -> reifyMethods (Service :: Service rest) ((MethodHandler (Method :: Method name req resp) f):hx)
+
+-- this is a convenience helper until we have a better solution.
+split :: (Char -> Bool) -> String -> [String]
+split p s = case dropWhile p s of
+  "" -> []
+  s' -> w : split p s''
+    where (w, s'') = break p s'

--- a/Text/ProtocolBuffers/Services.hs
+++ b/Text/ProtocolBuffers/Services.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE ConstraintKinds           #-}
+{-# LANGUAGE DataKinds                 #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE KindSignatures            #-}
+{-# LANGUAGE MultiParamTypeClasses     #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE TypeOperators             #-}
+module Text.ProtocolBuffers.Services(
+    MethodCxt
+  , MethodHandler(..)
+  , methodName
+  , reifyMethods
+  ) where
+
+import           Text.ProtocolBuffers.Basic
+import           Text.ProtocolBuffers.Reflections hiding (methodName)
+import           Text.ProtocolBuffers.WireMessage
+
+import           Data.Proxy
+import           GHC.TypeLits
+
+-- | A convenience type alias for constraints on methods.
+type MethodCxt name req resp = ( ReflectDescriptor req
+                               , ReflectDescriptor resp
+                               , Wire req
+                               , Wire resp
+                               , KnownSymbol name
+                               )
+
+-- | The name of a method.
+methodName :: forall name req resp . KnownSymbol name => Method name req resp -> String
+methodName _ = symbolVal (Proxy :: Proxy name)
+
+-- | A reified method attached with a function to execute the method.
+data MethodHandler m = forall name req resp. MethodCxt name req resp =>
+                       MethodHandler (Method name req resp) (req -> m resp)
+
+-- |This class can be used to reify a service to value level.
+class HasMethod (m :: * -> *) (a :: [*]) where
+  type MkHandler a m
+  reifyMethods :: Service a -> [MethodHandler m] ->  MkHandler a m
+
+instance HasMethod m '[] where
+  type MkHandler '[] m = [MethodHandler m]
+  reifyMethods _ hx = hx
+
+instance (HasMethod m rest, MethodCxt name req resp) => HasMethod m (Method name req resp ': rest) where
+  type MkHandler (Method name req resp ': rest) m = (req -> m resp) -> MkHandler rest m
+  reifyMethods _ hx = \f -> reifyMethods (Service :: Service rest) ((MethodHandler (Method :: Method name req resp) f):hx)

--- a/Text/ProtocolBuffers/Services.hs
+++ b/Text/ProtocolBuffers/Services.hs
@@ -51,7 +51,7 @@ serviceName _ = name
 packageName :: forall name req resp. KnownSymbol name => Method name req resp -> String
 packageName _ = name
   where fqn = symbolVal (Proxy :: Proxy name)
-        name =  intercalate "." (drop 1 (init (init (split ('.' ==) fqn))))
+        name =  intercalate "." (init (init (split ('.' ==) fqn)))
 
 -- | A reified method attached with a function to execute the method.
 data MethodHandler m = forall name req resp. MethodCxt name req resp =>

--- a/hprotoc/Text/ProtocolBuffers/ProtoCompile.hs
+++ b/hprotoc/Text/ProtocolBuffers/ProtoCompile.hs
@@ -19,7 +19,7 @@ import System.IO (stdin, stdout)
 
 import Text.ProtocolBuffers.Basic(defaultValue, Utf8(..), utf8)
 import Text.ProtocolBuffers.Identifiers(MName,checkDIString,mangle)
-import Text.ProtocolBuffers.Reflections(ProtoInfo(..),EnumInfo(..),OneofInfo(..))
+import Text.ProtocolBuffers.Reflections(ProtoInfo(..),EnumInfo(..),OneofInfo(..),ServiceInfo(..))
 import Text.ProtocolBuffers.WireMessage (messagePut, messageGet)
 
 import qualified Text.DescriptorProtos.FileDescriptorProto as D(FileDescriptorProto)
@@ -28,7 +28,7 @@ import qualified Text.DescriptorProtos.FileDescriptorProto as D.FileDescriptorPr
 import qualified Text.DescriptorProtos.FileDescriptorSet   as D.FileDescriptorSet(FileDescriptorSet(..))
 
 import Text.ProtocolBuffers.ProtoCompile.BreakRecursion(makeResult,displayResult)
-import Text.ProtocolBuffers.ProtoCompile.Gen(protoModule,descriptorModules,enumModule,oneofModule)
+import Text.ProtocolBuffers.ProtoCompile.Gen(protoModule,descriptorModules,enumModule,oneofModule,serviceModule)
 import Text.ProtocolBuffers.ProtoCompile.MakeReflections(makeProtoInfo,serializeFDP)
 import Text.ProtocolBuffers.ProtoCompile.Resolve(loadProto,loadCodeGenRequest,makeNameMaps,getTLS
                                                 ,Env,LocalFP(..),CanonFP(..),TopLevel(..)
@@ -272,8 +272,12 @@ run' o@(Output print' writeFile') options env fdps = do
       produceONO oi = do
         let file = joinPath . oneofFilePath $ oi
         writeFile' file (prettyPrintStyleMode style myMode (oneofModule result oi))
+      produceSRV srv = do
+        let file = joinPath . serviceFilePath $ srv
+        writeFile' file (prettyPrintStyleMode style myMode (serviceModule result srv))
   mapM_ produceMSG (messages protoInfo)
   mapM_ produceENM (enums protoInfo)
   mapM_ produceONO (oneofs protoInfo)
+  mapM_ produceSRV (services protoInfo)
   let file = joinPath . protoFilePath $ protoInfo
   writeFile' file (prettyPrintStyleMode style myMode (protoModule result protoInfo (serializeFDP fdp)))

--- a/hprotoc/Text/ProtocolBuffers/ProtoCompile/Gen.hs
+++ b/hprotoc/Text/ProtocolBuffers/ProtoCompile/Gen.hs
@@ -615,9 +615,9 @@ serviceDecls si' =
       ( TyApp
         ( TyApp
           ( TyApp ( TyCon (private "Method")) (TyPromoted (PromotedString ( toString (  fiName (protobufName (methodName mi)) )))))
-          ( TyCon ( UnQual (baseIdent (methodInput mi) )))
+          ( TyCon ( qualName (methodInput mi) ) )
         )
-        ( TyCon (UnQual (baseIdent (methodOutput mi))) )
+        ( TyCon ( qualName (methodOutput mi)) )
       )
 
     methodProxy _si mi =

--- a/hprotoc/hprotoc.cabal
+++ b/hprotoc/hprotoc.cabal
@@ -35,7 +35,7 @@ Executable hprotoc
                    containers,
                    directory >= 1.0.0.1,
                    filepath >= 1.1.0.0,
-                   haskell-src-exts >= 1.16.0,
+                   haskell-src-exts >= 1.17.0,
                    mtl,
                    parsec,
                    utf8-string

--- a/hprotoc/hprotoc.cabal
+++ b/hprotoc/hprotoc.cabal
@@ -35,7 +35,7 @@ Executable hprotoc
                    containers,
                    directory >= 1.0.0.1,
                    filepath >= 1.1.0.0,
-                   haskell-src-exts >= 1.17.0,
+                   haskell-src-exts >= 1.16.0,
                    mtl,
                    parsec,
                    utf8-string

--- a/protocol-buffers.cabal
+++ b/protocol-buffers.cabal
@@ -29,6 +29,7 @@ Library
                    Text.ProtocolBuffers.Header
                    Text.ProtocolBuffers.Identifiers
                    Text.ProtocolBuffers.Reflections
+                   Text.ProtocolBuffers.Services
                    Text.ProtocolBuffers.TextMessage
                    Text.ProtocolBuffers.Unknown
                    Text.ProtocolBuffers.WireMessage


### PR DESCRIPTION
Hello, 

I open this pull request for discussion (started here https://github.com/k-bx/protocol-buffers/issues/9). I put client and server examples as use cases here. Please have look. 

Having a proto-definition like this: 

``` protobuf
message SearchRequest {
    required string query = 1;
    optional int32 page_number = 2;
    optional int32 result_per_page = 3;
}

message SearchResponse {
    repeated string results = 1;
}

message AutocompleteRequest {
    required string query = 1;
    optional int32 max_results = 2;
}

message AutocompleteResponse {
    repeated string results = 1;
}

service SearchService {
    rpc Search (SearchRequest) returns (SearchResponse);
    rpc Autocomplete(AutocompleteRequest) returns (AutocompleteResponse);
}
```

The service generator generates (omitting imports, exports and corresponding messages)

``` haskell

type SearchService = P'.Service '[Search, Autocomplete]

searchService :: SearchService
searchService = P'.Service

type Search = P'.Method ".Search.SearchService.Search" SearchRequest SearchResponse

type Autocomplete = P'.Method ".Search.SearchService.Autocomplete" AutocompleteRequest AutocompleteResponse

search :: Search
search = P'.Method

autocomplete :: Autocomplete
autocomplete = P'.Method

```

A `Service` consists of a type level list itself consisting of `Method`s. Each `Method` is parameterized with its method name as type-level string (via DataKinds extensions), its input parameter type and its output parameter type.

An implementor for a client of a protobuf service only has to interpret the method type for his calls like so: 

``` haskell
-- invoke reifies the Method type to value level. This is the adapter one has to
-- write in order use the generated method definitions.
invoke :: forall m name req resp . (MonadIO m, MethodCxt name req resp) => Method name req resp -> req -> RpcM m resp
invoke method = \req -> ... 
  where name = methodName method

main = do 
  runRpcM conn $ do

    -- invoke a search!
    SearchResponse rx <- invoke search SearchRequest { query = Utf8 "hello world"
                                                     , page_number = Nothing
                                                     , result_per_page = Nothing
                                                     }
    -- do something with SearchResponse
    liftIO $ print rx
```

Where 
- `MethodCxt` is a constraint given in `Text.ProtocolBuffers.Services`
- `methodName` is a function from `Method name req resp` to String also given in `Text.ProtocolBuffers.Services`

Any other constraints, like the monad in which the `invoke` operation is performed can be freely chosen by the implementor. Its important only to interpret the `Method name req resp` type.

On the server side an implementor needs to combine his `Method`s with corresponding handlers: 

``` haskell
doSearch :: SearchRequest -> SearchM SearchResponse 
doSearch req = do ... 

doAutocomplete :: AutocompleteRequest -> SearchM AutocompleteResponse
doAutocomplete req = do ... 

handlers :: [MethodHandler SearchM]
handlers = reifyMethods searchService [] 
                     doSearch
                     doAutocomplete

```

We define our handler functions `doSearch` and `doAutocomplete`. We use the `reifyMethods` function from `Text.ProtocolBuffers.Services` (note the `[]` argument, hopefully someone smarter than me can get rid of it) to get a list of `MethodHandler`s. `reifyMethods` expands to a function taking a well-typed handler function for each method in the service definiton.   

``` haskell
-- | A reified method attached with a function to execute the method.
data MethodHandler m = forall name req resp. MethodCxt name req resp =>
                       MethodHandler (Method name req resp) (req -> m resp)
```

A `MethodHandler` is basically the method name and an action which takes the methods input parameter and outputs a response in some context `m`.

It follows a more elaborated example using `binary`s facilities to process messages: 

``` haskell
data SomeHeader = SomeHeader { hdMethod    :: !ByteString
                             , hdPayloadSz :: !Word32
                             }

-- This turns bytestrings into actions which handle the incoming service calls,
-- which in turn respond with a put to put it back on the wire/file.
-- Again, we are free to handle the methods as we want, no constraints given through
-- the encoding of methods.
handle :: Functor m => [MethodHandler m] -> LByteString.ByteString -> Result (m Put.Put)
handle methods =
  runGet (do mSz <- fromIntegral <$> getWord8
             SomeHeader{..} <- SomeHeader <$> getByteString mSz <*> getWord32be
             case Map.lookup hdMethod methods' of
               Just (MethodHandler _ f) -> do
                 req <- messageGetM
                 return (messagePutM <$> f req)
               Nothing -> fail "invalid method")
  where
    -- An efficient mapping from method names to their handlers
    methods' = Map.fromList [ (m, mh) | mh@(MethodHandler method _) <- methods
                                      , let m = ByteString.pack (methodName method) ]
```

The resulting (possibly) monadic action from `handle` produces a result from the input parameter and just generates a response which is in turn directly serialized to a `Put` again. Again the implementor is free to run their actions in any context and is not constraint in his freedom of choice for Api. 
