### PR TITLE
Add support for map<k,v> proto syntax

### DIFF
--- a/Text/ProtocolBuffers/Basic.hs
+++ b/Text/ProtocolBuffers/Basic.hs
@@ -5,7 +5,7 @@
 -- 'Default' classes. The 'Wire' class is not defined here to avoid orphans.
 module Text.ProtocolBuffers.Basic
   ( -- * Basic types for protocol buffer fields in Haskell
-    Double,Float,Bool,Maybe,Seq,Utf8(Utf8),ByteString,Int32,Int64,Word32,Word64
+    Double,Float,Bool,Maybe,Seq,Map.Map,Utf8(Utf8),ByteString,Int32,Int64,Word32,Word64
     -- * Haskell types that act in the place of DescritorProto values
   , WireTag(..),FieldId(..),WireType(..),FieldType(..),EnumCode(..),WireSize
     -- * Some of the type classes implemented messages and fields
@@ -28,6 +28,8 @@ import Data.Word(Word8,Word32,Word64)
 
 import qualified Data.ByteString.Lazy as L(unpack)
 import Data.ByteString.Lazy.UTF8 as U (toString,fromString)
+
+import qualified Data.Map as Map
 
 -- Num instances are derived below for the purpose of getting fromInteger for case matching
 
@@ -237,6 +239,9 @@ instance Mergeable (Seq a) where
 --    mergeEmpty = empty
     mergeAppend = (><)
 
+instance Ord k => Mergeable (Map.Map k v) where
+    mergeAppend = Map.union
+
 -- These all have errors as mergeEmpty and use the second paramater for mergeAppend
 instance Mergeable Bool
 instance Mergeable Utf8
@@ -257,5 +262,6 @@ instance Default Double where defaultValue = 0
 instance Default Bool where defaultValue = False
 instance Default (Maybe a) where defaultValue = Nothing
 instance Default (Seq a) where defaultValue = mempty
+instance Ord k => Default (Map.Map k v) where defaultValue = mempty
 instance Default ByteString where defaultValue = mempty
 instance Default Utf8 where defaultValue = mempty

--- a/Text/ProtocolBuffers/Extensions.hs
+++ b/Text/ProtocolBuffers/Extensions.hs
@@ -32,7 +32,6 @@ module Text.ProtocolBuffers.Extensions
 import Control.Monad.Error.Class(throwError)
 import qualified Data.ByteString.Lazy as L
 import qualified Data.Foldable as F
-import Data.Map(Map)
 import qualified Data.Map as M
 import Data.Maybe(fromMaybe,isJust)
 #if __GLASGOW_HASKELL__ < 710

--- a/Text/ProtocolBuffers/Header.hs
+++ b/Text/ProtocolBuffers/Header.hs
@@ -2,7 +2,7 @@
 -- compile.  This and the Prelude will both be imported qualified as
 -- P', the prime ensuring no name conflicts are possible.
 module Text.ProtocolBuffers.Header
-    ( append, emptyBS
+    ( append, appendMap, emptyBS
     , pack, fromMaybe, ap
     , fromDistinctAscList, member
     , throwError,catchError
@@ -24,6 +24,7 @@ import Data.ByteString.Lazy.Char8(pack)
 import Data.Generics(Data(..))
 import Data.Maybe(fromMaybe)
 import Data.Sequence((|>)) -- for append, see below
+import qualified Data.Map as Map
 import Data.Set(fromDistinctAscList,member)
 import Text.Parsec(choice, sepEndBy, spaces, try)
 
@@ -53,6 +54,10 @@ import Text.ProtocolBuffers.WireMessage
 {-# INLINE append #-}
 append :: Seq a -> a -> Seq a
 append = (|>)
+
+{-# INLINE appendMap #-}
+appendMap :: Ord k => Map.Map k v -> (k, v) -> Map.Map k v
+appendMap = flip (uncurry Map.insert)
 
 {-# INLINE emptyBS #-}
 emptyBS :: ByteString

--- a/Text/ProtocolBuffers/Reflections.hs
+++ b/Text/ProtocolBuffers/Reflections.hs
@@ -28,7 +28,6 @@ import Data.Set(Set)
 import qualified Data.Set as Set(fromDistinctAscList)
 import Data.Generics(Data)
 import Data.Typeable(Typeable)
-import Data.Map(Map)
 
 -- | 'makePNF' is used by the generated code to create a ProtoName with less newtype noise.
 makePNF :: ByteString -> [String] -> [String] -> String -> ProtoName

--- a/Text/ProtocolBuffers/Reflections.hs
+++ b/Text/ProtocolBuffers/Reflections.hs
@@ -82,6 +82,7 @@ data DescriptorInfo = DescriptorInfo { descName :: ProtoName
                                      , storeUnknown :: Bool
                                      , lazyFields :: Bool
                                      , makeLenses :: Bool
+                                     , mapEntry   :: Bool
                                      }
   deriving (Show,Read,Eq,Ord,Data,Typeable)
 
@@ -113,6 +114,8 @@ data FieldInfo = FieldInfo { fieldName     :: ProtoFName
                            , typeName      :: Maybe ProtoName  -- ^ Set for Messages,Groups,and Enums
                            , hsRawDefault  :: Maybe ByteString -- ^ crappy, but not escaped, thing
                            , hsDefault     :: Maybe HsDefault  -- ^ nice parsed thing
+                           , isMapField    :: Bool             -- ^ whether the field is map field
+                           , mapKeyVal     :: Maybe ((FieldType, Maybe ProtoName), (FieldType, Maybe ProtoName)) -- ^ types of key and value fields
                            }
   deriving (Show,Read,Eq,Ord,Data,Typeable)
 

--- a/Text/ProtocolBuffers/WireMessage.hs
+++ b/Text/ProtocolBuffers/WireMessage.hs
@@ -45,7 +45,7 @@ import Data.Bits (Bits(..))
 --import qualified Data.ByteString as S(last)
 --import qualified Data.ByteString.Unsafe as S(unsafeIndex)
 import qualified Data.ByteString.Lazy as BS (length)
-import qualified Data.Foldable as F (Foldable, foldl', forM_)
+import qualified Data.Foldable as F (foldl', forM_)
 --import Data.List (genericLength)
 import Data.Maybe(fromMaybe)
 import Data.Sequence ((|>))
@@ -237,12 +237,12 @@ wireSizeOpt tagSize i (Just v) = wireSizeReq tagSize i v
 
 {-# INLINE wireSizeRep #-}
 -- | Used in generated code.
-wireSizeRep :: (F.Foldable f, Wire v) => Int64 -> FieldType -> f v -> Int64
+wireSizeRep :: Wire v => Int64 -> FieldType -> Seq v -> Int64
 wireSizeRep tagSize i vs = F.foldl' (\n v -> n + wireSizeReq tagSize i v) 0 vs
 
 {-# INLINE wireSizePacked #-}
 -- | Used in generated code.
-wireSizePacked :: (F.Foldable f, Wire v) => Int64 -> FieldType -> f v -> Int64
+wireSizePacked :: Wire v => Int64 -> FieldType -> Seq v -> Int64
 wireSizePacked tagSize i vs = tagSize + prependMessageSize (F.foldl' (\n v -> n + wireSize i v) 0 vs)
 
 {-# INLINE putSize #-}

--- a/Text/ProtocolBuffers/WireMessage.hs
+++ b/Text/ProtocolBuffers/WireMessage.hs
@@ -237,12 +237,12 @@ wireSizeOpt tagSize i (Just v) = wireSizeReq tagSize i v
 
 {-# INLINE wireSizeRep #-}
 -- | Used in generated code.
-wireSizeRep :: Wire v => Int64 -> FieldType -> Seq v -> Int64
+wireSizeRep :: (Foldable f, Wire v) => Int64 -> FieldType -> f v -> Int64
 wireSizeRep tagSize i vs = F.foldl' (\n v -> n + wireSizeReq tagSize i v) 0 vs
 
 {-# INLINE wireSizePacked #-}
 -- | Used in generated code.
-wireSizePacked :: Wire v => Int64 -> FieldType -> Seq v -> Int64
+wireSizePacked :: (Foldable f, Wire v) => Int64 -> FieldType -> f v -> Int64
 wireSizePacked tagSize i vs = tagSize + prependMessageSize (F.foldl' (\n v -> n + wireSize i v) 0 vs)
 
 {-# INLINE putSize #-}

--- a/Text/ProtocolBuffers/WireMessage.hs
+++ b/Text/ProtocolBuffers/WireMessage.hs
@@ -45,7 +45,7 @@ import Data.Bits (Bits(..))
 --import qualified Data.ByteString as S(last)
 --import qualified Data.ByteString.Unsafe as S(unsafeIndex)
 import qualified Data.ByteString.Lazy as BS (length)
-import qualified Data.Foldable as F(foldl',forM_)
+import qualified Data.Foldable as F (Foldable, foldl', forM_)
 --import Data.List (genericLength)
 import Data.Maybe(fromMaybe)
 import Data.Sequence ((|>))
@@ -237,12 +237,12 @@ wireSizeOpt tagSize i (Just v) = wireSizeReq tagSize i v
 
 {-# INLINE wireSizeRep #-}
 -- | Used in generated code.
-wireSizeRep :: (Foldable f, Wire v) => Int64 -> FieldType -> f v -> Int64
+wireSizeRep :: (F.Foldable f, Wire v) => Int64 -> FieldType -> f v -> Int64
 wireSizeRep tagSize i vs = F.foldl' (\n v -> n + wireSizeReq tagSize i v) 0 vs
 
 {-# INLINE wireSizePacked #-}
 -- | Used in generated code.
-wireSizePacked :: (Foldable f, Wire v) => Int64 -> FieldType -> f v -> Int64
+wireSizePacked :: (F.Foldable f, Wire v) => Int64 -> FieldType -> f v -> Int64
 wireSizePacked tagSize i vs = tagSize + prependMessageSize (F.foldl' (\n v -> n + wireSize i v) 0 vs)
 
 {-# INLINE putSize #-}

--- a/hprotoc/Text/ProtocolBuffers/ProtoCompile/Gen.hs
+++ b/hprotoc/Text/ProtocolBuffers/ProtoCompile/Gen.hs
@@ -696,9 +696,15 @@ descriptorNormalModule result di
         -- Sequence
         map_field_exports =
             if mapEntry di then
+#if MIN_VERSION_haskell_src_exts(1, 17, 0)
                 [ EVar $ mapFieldHelperFn (descName di) "ToPair" False
                 , EVar $ mapFieldHelperFn (descName di) "ToSeq" False
                 ]
+#else
+                [ EVar NoNamespace $ mapFieldHelperFn (descName di) "ToPair" False
+                , EVar NoNamespace $ mapFieldHelperFn (descName di) "ToSeq" False
+                ]
+#endif
             else
                 []
         imports = (standardImports False (hasExt di) (makeLenses di) (mapEntry di) ++) . mergeImports . concat $
@@ -761,7 +767,7 @@ declMapHelpers di
                 Nothing                       {-type-}
                 (Hse.UnGuardedRhs $           {-rhs-}
                     Hse.Tuple Hse.Boxed [lvar "k", lvar "v"])
-                Nothing                       {-binds-}
+                noWhere                       {-binds-}
             ]
         -- toSeq :: Map.Map KEY VAL -> Seq MOD
         -- toSeq x = Seq.fromList (Prelude'.map (Prelude'.uncurry Map_field_Entry) (Map.toList x))
@@ -780,7 +786,7 @@ declMapHelpers di
                                     (Con (unqualName (descName di)))))
                             (App (mapMod "toList") (lvar "x")))
                 )
-                Nothing
+                noWhere
             ]
         mapMod t = Var (Qual (ModuleName "Map") (Ident t))
         seqMod t = Var (Qual (ModuleName "Seq") (Ident t))

--- a/hprotoc/Text/ProtocolBuffers/ProtoCompile/Lexer.x
+++ b/hprotoc/Text/ProtocolBuffers/ProtoCompile/Lexer.x
@@ -33,7 +33,7 @@ $d = [0-9]
 @inStr = @hexEscape | @octEscape | @charEscape | [^'\"\n] | [\0]
 @strLit = ['] (@inStr | [\"])* ['] | [\"] (@inStr | ['])* [\"]
 
-$special    = [=\(\)\,\;\[\]\{\}\.\:]
+$special    = [\<\>=\(\)\,\;\[\]\{\}\.\:]
 
 @ninf = [\-][i][n][f]
 

--- a/hprotoc/Text/ProtocolBuffers/ProtoCompile/MakeReflections.hs
+++ b/hprotoc/Text/ProtocolBuffers/ProtoCompile/MakeReflections.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 -- | The 'MakeReflections' module takes the 'FileDescriptorProto'
 -- output from 'Resolve' and produces a 'ProtoInfo' from
 -- 'Reflections'.  This also takes a Haskell module prefix and the
@@ -37,6 +38,7 @@ import qualified Text.DescriptorProtos.FileDescriptorProto            as D(FileD
 import qualified Text.DescriptorProtos.FileDescriptorProto            as D.FileDescriptorProto(FileDescriptorProto(..)) 
 import qualified Text.DescriptorProtos.OneofDescriptorProto           as D(OneofDescriptorProto)
 import qualified Text.DescriptorProtos.OneofDescriptorProto           as D.OneofDescriptorProto(OneofDescriptorProto(..))
+import qualified Text.DescriptorProtos.MessageOptions                 as D.MessageOptions
 
 import Text.ProtocolBuffers.Basic
 import Text.ProtocolBuffers.Identifiers
@@ -47,15 +49,16 @@ import Text.ProtocolBuffers.ProtoCompile.Resolve(ReMap,NameMap(..),getPackageID)
 -- import Text.ProtocolBuffers.Reflections
 
 import qualified Data.Foldable as F(foldr,toList)
-import           Data.Sequence ((<|))
-import qualified Data.Sequence as Seq(fromList,empty,singleton,null,filter)
+import           Data.Sequence ((<|),(><))
+import qualified Data.Sequence as Seq
 import Numeric(readHex,readOct,readDec)
 import Data.Monoid(mconcat,mappend)
 import qualified Data.Map as M(fromListWith,lookup,keys)
-import Data.Maybe(fromMaybe,catMaybes,fromJust)
+import Data.Maybe(fromMaybe,catMaybes,fromJust,isJust)
 import System.FilePath
 
---import Debug.Trace (trace)
+import qualified Data.List as List
+import qualified Data.ByteString.Lazy.Char8 as BL8
 
 imp :: String -> a
 imp msg = error $ "Text.ProtocolBuffers.ProtoCompile.MakeReflections: Impossible?\n  "++msg
@@ -84,7 +87,7 @@ makeProtoInfo (unknownField,lazyFieldsOpt,lenses) (NameMap (packageID,hPrefix,hP
                         [] -> imp $ "makeProtoInfo: no hPrefix or hParent in NameMap for: "++show fdp
                         _ -> ProtoName packageName (init hPrefix) [] (last hPrefix)
                 _ -> ProtoName packageName hPrefix (init hParent) (last hParent)
-  keyInfos = Seq.fromList . map (\f -> (keyExtendee' reMap f,toFieldInfo' reMap packageName lenses f))
+  keyInfos = Seq.fromList . map (\f -> (keyExtendee' reMap f,toFieldInfo' reMap packageName lenses Nothing f))
              . F.toList . D.FileDescriptorProto.extension $ fdp
   allMessages = concatMap (processMSG packageName False) (F.toList $ D.FileDescriptorProto.message_type fdp)
   allEnums = map (makeEnumInfo' reMap packageName) (F.toList $ D.FileDescriptorProto.enum_type fdp) 
@@ -145,7 +148,7 @@ makeOneofInfo' reMap parent lenses parentProto
           = case D.FieldDescriptorProto.name fdp of
               Just name -> toHaskell reMap $ fqAppend (protobufName protoName) [IName name]
               Nothing -> imp $ "getFieldProtoName: missing info in " ++ show fdp
-        getFieldInfo = toFieldInfo' reMap (protobufName protoName) lenses
+        getFieldInfo = toFieldInfo' reMap (protobufName protoName) lenses Nothing
         fieldInfos = fmap (\x->(getFieldProtoName x,getFieldInfo x)) rawFieldsOneof
 makeOneofInfo' _ _ _ _ _ = imp "makeOneofInfo: missing name"
 
@@ -165,24 +168,49 @@ makeDescriptorInfo' :: ReMap -> FIName Utf8
                     -> (Bool,Bool,Bool) -- unknownField, lazyFields and lenses
                     -> D.DescriptorProto -> DescriptorInfo
 makeDescriptorInfo' reMap parent getKnownKeys msgIsGroup (unknownField,lazyFieldsOpt,lenses)
-                    msg@(D.DescriptorProto.DescriptorProto
+                    msg@D.DescriptorProto.DescriptorProto
                       { D.DescriptorProto.name = Just rawName
                       , D.DescriptorProto.field = rawFields
                       , D.DescriptorProto.oneof_decl = rawOneofs
                       , D.DescriptorProto.extension = rawKeys
-                      , D.DescriptorProto.extension_range = extension_range })
-    = let di = DescriptorInfo protoName (pnPath protoName) msgIsGroup 
-                              fieldInfos oneofInfos keyInfos extRangeList
-                              (getKnownKeys protoName)
-                              unknownField lazyFieldsOpt lenses
-      in di -- trace (toString rawName ++ "\n" ++ show di ++ "\n\n") $ di
+                      , D.DescriptorProto.extension_range = extension_range
+                      }
+    = DescriptorInfo
+        { descName     = protoName
+        , descFilePath = pnPath protoName
+        , isGroup      = msgIsGroup
+        , fields       = fieldInfos
+        , descOneofs   = oneofInfos
+        , keys         = keyInfos
+        , extRanges    = extRangeList
+        , knownKeys    = getKnownKeys protoName
+        , storeUnknown = unknownField
+        , lazyFields   = lazyFieldsOpt
+        , makeLenses   = lenses
+        , mapEntry     = case D.DescriptorProto.options msg of
+                            Just D.MessageOptions.MessageOptions{
+                                D.MessageOptions.map_entry = Just True
+                            } -> True
+                            _ -> False
+        }
   where protoName = toHaskell reMap $ fqAppend parent [IName rawName]
-        rawFieldsNotOneof = Seq.filter (\x -> D.FieldDescriptorProto.oneof_index x == Nothing) rawFields
-        fieldInfos = fmap (toFieldInfo' reMap (protobufName protoName) lenses) rawFieldsNotOneof
+        rawFieldsNotOneof =
+            -- and not oneof
+            Seq.filter (\x -> D.FieldDescriptorProto.oneof_index x == Nothing) $
+            -- not map
+            Seq.filter (`List.notElem` mapFields) rawFields
+
+        fieldInfos =
+            fmap (toFieldInfo' reMap (protobufName protoName) lenses Nothing) rawFieldsNotOneof
+            ><
+            fmap (\x ->
+                toFieldInfo' reMap (protobufName protoName) lenses (findFieldKV x) x) mapFields
+
         oneofInfos = F.foldr ((<|) . makeOneofInfo' reMap (protobufName protoName) lenses msg) Seq.empty
                           (zip [0..] (F.toList rawOneofs))
-          
-        keyInfos = fmap (\f -> (keyExtendee' reMap f,toFieldInfo' reMap (protobufName protoName) lenses f)) rawKeys
+
+        keyInfos = fmap (\f -> (keyExtendee' reMap f,toFieldInfo' reMap (protobufName protoName) lenses Nothing f)) rawKeys
+
         extRangeList = concatMap check unchecked
           where check x@(lo,hi) | hi < lo = []
                                 | hi<19000 || 19999<lo  = [x]
@@ -192,15 +220,93 @@ makeDescriptorInfo' reMap parent getKnownKeys msgIsGroup (unknownField,lazyField
                             { D.DescriptorProto.ExtensionRange.start = mStart
                             , D.DescriptorProto.ExtensionRange.end = mEnd }) =
                   (maybe minBound FieldId mStart, maybe maxBound (FieldId . pred) mEnd)
+
+        -- | Given a DescriptorProto for map entry, extract types of "key" and
+        -- "value" fields
+        kvTypes
+            :: D.DescriptorProto.DescriptorProto
+            -> ((FieldType, Maybe ProtoName), (FieldType, Maybe ProtoName))
+        kvTypes dp =
+            let fields_ = F.toList $ D.DescriptorProto.field dp in
+            -- key, value fields
+            let Just kf = List.find
+                    (\fdp -> D.FieldDescriptorProto.name fdp == Just (Utf8 "key"))
+                    fields_
+            in
+            let Just vf = List.find
+                    (\fdp -> D.FieldDescriptorProto.name fdp == Just (Utf8 "value"))
+                    fields_
+            in
+            -- key, value field infos
+            let kfi = toFieldInfo' reMap (protobufName protoName) lenses Nothing kf in
+            let vfi = toFieldInfo' reMap (protobufName protoName) lenses Nothing vf in
+            -- key, value type code and type names
+            let ktc = (typeCode kfi, typeName kfi) in
+            let vtc = (typeCode vfi, typeName vfi) in
+            (ktc, vtc)
+
+        -- | Given a FieldDescriptorProto of a map field find the corresponding
+        -- DescriptorProto of the _Entry module and extract the types of its
+        -- "key" and "value" fields
+        findFieldKV
+            :: D.FieldDescriptorProto.FieldDescriptorProto
+            -> Maybe ((FieldType, Maybe ProtoName), (FieldType, Maybe ProtoName))
+        findFieldKV fdp =
+            let getType (Utf8 x) = Utf8 $ last (BL8.split '.' x) in
+            kvTypes <$>
+                List.find
+                    (\dp_ ->
+                        D.DescriptorProto.name dp_
+                        ==
+                        (getType <$> D.FieldDescriptorProto.type_name fdp)
+                    )
+                    mapEntries
+
+        -- map field entry (k,v) wrappers
+        mapEntries :: [D.DescriptorProto.DescriptorProto]
+        mapEntries =
+            -- convert to list because it's easier to search
+            F.toList $
+            Seq.filter
+                (\x -> case x of
+                    D.DescriptorProto.DescriptorProto {
+                       D.DescriptorProto.options =
+                            Just D.MessageOptions.MessageOptions{
+                                D.MessageOptions.map_entry = Just True
+                            }
+                    } -> True
+                    _ -> False
+                )
+                (D.DescriptorProto.nested_type msg)
+
+        -- There is nothing in FieldDescriptorProto to distinguish a map field
+        -- (since they are just sequences). Hence, find all fields such that
+        -- the DescriptorProtos of their types have map_entry option set
+        mapFields :: Seq D.FieldDescriptorProto
+        mapFields =
+            Seq.filter
+                (\fld ->
+                    let getType (Utf8 f) = Utf8 $ last (BL8.split '.' f) in
+                    let tn = D.FieldDescriptorProto.type_name fld in
+                    let xs =
+                            List.filter
+                                (\y -> D.DescriptorProto.name y == (getType <$> tn))
+                                mapEntries
+                    in
+                    not (List.null xs)
+                )
+                rawFields
 makeDescriptorInfo' _ _ _ _ _ _ = imp $ "makeDescriptorInfo: missing name"
 
 toFieldInfo'
   :: ReMap
   -> FIName Utf8
   -> Bool -- ^ whether to use lences (if True, an underscore prefix is used)
+  -- if the field is a map field: (k,v) types
+  -> Maybe ((FieldType, Maybe ProtoName), (FieldType, Maybe ProtoName))
   -> D.FieldDescriptorProto
   -> FieldInfo
-toFieldInfo' reMap parent lenses
+toFieldInfo' reMap parent lenses mapKV
              f@(D.FieldDescriptorProto.FieldDescriptorProto
                  { D.FieldDescriptorProto.name = Just name
                  , D.FieldDescriptorProto.number = Just number
@@ -243,7 +349,9 @@ toFieldInfo' reMap parent lenses
                                  (fmap (toHaskell reMap . FIName) mayTypeName)
                                  (fmap utf8 mayRawDef)
                                  mayDef
-toFieldInfo' _ _ _ f = imp $ "toFieldInfo: missing info in "++show f
+                                 (isJust mapKV) {- isMapField -}
+                                 mapKV          {- (k,v) types -}
+toFieldInfo' _ _ _ _ f = imp $ "toFieldInfo: missing info in "++show f
 
 collectedGroups :: D.DescriptorProto -> [Utf8] 
 collectedGroups = catMaybes

--- a/hprotoc/Text/ProtocolBuffers/ProtoCompile/MakeReflections.hs
+++ b/hprotoc/Text/ProtocolBuffers/ProtoCompile/MakeReflections.hs
@@ -52,7 +52,6 @@ import qualified Data.Foldable as F(foldr,toList)
 import           Data.Sequence ((<|),(><))
 import qualified Data.Sequence as Seq
 import Numeric(readHex,readOct,readDec)
-import Data.Monoid(mconcat,mappend)
 import qualified Data.Map as M(fromListWith,lookup,keys)
 import Data.Maybe(fromMaybe,catMaybes,fromJust,isJust)
 import System.FilePath
@@ -137,8 +136,8 @@ makeOneofInfo' :: ReMap -> FIName Utf8
                -> Bool -- ^ makeLenses
                -> D.DescriptorProto -> (Int32,D.OneofDescriptorProto) -> OneofInfo
 makeOneofInfo' reMap parent lenses parentProto
-              (n, e@(D.OneofDescriptorProto.OneofDescriptorProto
-                  { D.OneofDescriptorProto.name = Just rawName }))
+              (n, D.OneofDescriptorProto.OneofDescriptorProto
+                  { D.OneofDescriptorProto.name = Just rawName })
     = OneofInfo protoName protoFName (pnPath protoName) fieldInfos lenses
   where protoName@(ProtoName x a b c) = toHaskell reMap $ fqAppend parent [IName rawName]
         protoFName = ProtoFName x a b (mangle c) (if lenses then "_" else "")
@@ -149,7 +148,7 @@ makeOneofInfo' reMap parent lenses parentProto
               Just name -> toHaskell reMap $ fqAppend (protobufName protoName) [IName name]
               Nothing -> imp $ "getFieldProtoName: missing info in " ++ show fdp
         getFieldInfo = toFieldInfo' reMap (protobufName protoName) lenses Nothing
-        fieldInfos = fmap (\x->(getFieldProtoName x,getFieldInfo x)) rawFieldsOneof
+        fieldInfos = fmap (\f -> (getFieldProtoName f, getFieldInfo f)) rawFieldsOneof
 makeOneofInfo' _ _ _ _ _ = imp "makeOneofInfo: missing name"
 
 

--- a/hprotoc/Text/ProtocolBuffers/ProtoCompile/Parser.hs
+++ b/hprotoc/Text/ProtocolBuffers/ProtoCompile/Parser.hs
@@ -606,13 +606,13 @@ mapField = do
         }
     let field = defaultValue {
           D.FieldDescriptorProto.name      = Just self,
-          D.FieldDescriptorProto.number    = Just 1,
+          D.FieldDescriptorProto.number    = Just number,
           D.FieldDescriptorProto.label     = Just LABEL_REPEATED,
           D.FieldDescriptorProto.type_name = Just entryName
         }
     update' $ \s -> s
-        { D.DescriptorProto.nested_type=Seq.fromList [mapFieldEntry]
-        , D.DescriptorProto.field=Seq.fromList [field]
+        { D.DescriptorProto.nested_type = D.DescriptorProto.nested_type s |> mapFieldEntry
+        , D.DescriptorProto.field       = D.DescriptorProto.field s       |> field
         }
 
 enum :: (D.EnumDescriptorProto -> P s ()) -> P s ()

--- a/hprotoc/Text/ProtocolBuffers/ProtoCompile/Parser.hs
+++ b/hprotoc/Text/ProtocolBuffers/ProtoCompile/Parser.hs
@@ -565,7 +565,7 @@ mapField = do
     pChar '<'
     keyType   <- ident1
     pChar ','
-    valueType <- ident1
+    valueType <- ident
     pChar '>'
     self      <- ident1
     number    <- pChar '=' >> enumInt

--- a/hprotoc/Text/ProtocolBuffers/ProtoCompile/Parser.hs
+++ b/hprotoc/Text/ProtocolBuffers/ProtoCompile/Parser.hs
@@ -63,7 +63,7 @@ import qualified Data.ByteString.Lazy.UTF8 as U(fromString,toString)
 import Data.Char(isUpper,toLower)
 import Data.Ix(inRange)
 import Data.Maybe(fromMaybe)
-import Data.Monoid(mconcat)
+import Data.Monoid(mconcat,(<>))
 import Data.Sequence((|>),(><))
 import qualified Data.Sequence as Seq(fromList,length,empty)
 import Data.Word(Word8)
@@ -73,6 +73,8 @@ import Text.ParserCombinators.Parsec(GenParser,ParseError,runParser,sourceName,a
                                     ,getInput,setInput,getPosition,setPosition,getState,setState
                                     ,(<?>),(<|>),token,choice,between,eof,unexpected,skipMany)
 import Text.ParserCombinators.Parsec.Pos(newPos)
+
+import qualified Text.ProtocolBuffers.Header as P'
 
 default ()
 
@@ -375,6 +377,7 @@ subMessage = (pChar '}') <|> (choice [ eol
                                      , field upNestedMsg Nothing >>= upMsgField
                                      , message upNestedMsg
                                      , enum upNestedEnum
+                                     , mapField
                                      , oneof upMsgOneof
                                      , extensions
                                      , extend upNestedMsg upExtField
@@ -533,6 +536,84 @@ isValidPacked LABEL_REPEATED (Just typeCode) =
     TYPE_ENUM -> True     -- Impossible value for typeCode from parseType, but here for completeness
     _ -> True
 isValidPacked _ _ = False
+
+-- mapField = "map" "<" keyType "," type ">" mapName "=" fieldNumber [ "[" fieldOptions "]" ] ";"
+-- keyType = "int32" | "int64" | "uint32" | "uint64" | "sint32" | "sint64" |
+--           "fixed32" | "fixed64" | "sfixed32" | "sfixed64" | "bool" | "string"
+--
+-- Protobuf:
+-- map<key_type, value_type> map_field = N;
+--
+-- Equivalent to:
+-- message value_type {}
+--
+-- message MapFieldEntry {
+--   key_type key = 1;
+--   value_type value = 2;
+-- }
+--
+-- repeated MapFieldEntry map_field = N;
+--
+-- In Haskell:
+-- module ValueType
+-- module Map_field_Entry where Map_field_Entry { key :: KeyType, value :: ValueType }
+-- Map_field.Entry where Entry { key :: KeyType, value :: ValueType }
+
+mapField :: P D.DescriptorProto.DescriptorProto ()
+mapField = do
+    pName (U.fromString "map")
+    pChar '<'
+    keyType   <- ident1
+    pChar ','
+    valueType <- ident1
+    pChar '>'
+    self      <- ident1
+    number    <- pChar '=' >> enumInt
+
+    let typeTypeName t1 =
+            case parseType (uToString t1) of
+              Just t2 -> (Just t2, Nothing)
+              Nothing -> (Nothing, Just t1)
+    -- key
+    let key =
+            let (maybeTypeCode, maybeTypeName)   = typeTypeName keyType in
+            defaultValue {
+                D.FieldDescriptorProto.name      = Just $ P'.Utf8 $ U.fromString "key",
+                D.FieldDescriptorProto.number    = Just 1,
+                D.FieldDescriptorProto.label     = Just LABEL_REQUIRED,
+                D.FieldDescriptorProto.type'     = maybeTypeCode,
+                D.FieldDescriptorProto.type_name = maybeTypeName
+            }
+    -- value
+    let value =
+            let (maybeTypeCode, maybeTypeName)   = typeTypeName valueType in
+            defaultValue {
+                D.FieldDescriptorProto.name      = Just $ P'.Utf8 $ U.fromString "value",
+                D.FieldDescriptorProto.number    = Just 2,
+                D.FieldDescriptorProto.label     = Just LABEL_REQUIRED,
+                D.FieldDescriptorProto.type'     = maybeTypeCode,
+                D.FieldDescriptorProto.type_name = maybeTypeName
+            }
+    -- Map_field_Entry: (key,value) pair
+    let entryName = self <> (P'.Utf8 (U.fromString "_Entry"))
+    let mapFieldEntry = defaultValue {
+          D.DescriptorProto.name    = Just entryName,
+          D.DescriptorProto.field   = Seq.fromList [key, value],
+          D.DescriptorProto.options =
+                Just $ defaultValue {
+                    D.MessageOptions.map_entry = Just True
+                }
+        }
+    let field = defaultValue {
+          D.FieldDescriptorProto.name      = Just self,
+          D.FieldDescriptorProto.number    = Just 1,
+          D.FieldDescriptorProto.label     = Just LABEL_REPEATED,
+          D.FieldDescriptorProto.type_name = Just entryName
+        }
+    update' $ \s -> s
+        { D.DescriptorProto.nested_type=Seq.fromList [mapFieldEntry]
+        , D.DescriptorProto.field=Seq.fromList [field]
+        }
 
 enum :: (D.EnumDescriptorProto -> P s ()) -> P s ()
 enum up = pName (U.fromString "enum") >> do

--- a/hprotoc/test/map-2/Makefile
+++ b/hprotoc/test/map-2/Makefile
@@ -1,0 +1,14 @@
+test: hs/encode_map hs/decode_map
+	@echo "\nHS -> HS\n" && \
+	./hs/encode_map | ./hs/decode_map
+
+hs/encode_map: hs/encode_map.hs
+	cd hs && make encode_map
+
+hs/decode_map: hs/decode_map.hs
+	cd hs && make decode_map
+
+clean:
+	cd hs; make clean; cd ..;
+
+.PHONY: clean

--- a/hprotoc/test/map-2/hs/Makefile
+++ b/hprotoc/test/map-2/hs/Makefile
@@ -1,0 +1,23 @@
+GHC=stack exec ghc --
+
+HPROTOC=stack exec hprotoc --
+
+test: encode_map decode_map
+	./encode_map | ./decode_map
+
+decode_map: Mymap decode_map.hs
+	${GHC} --make -O1 decode_map.hs
+
+encode_map: Mymap SomeType encode_map.hs
+	${GHC} --make -O1 encode_map.hs
+
+Mymap:
+	${HPROTOC} --proto_path=.. mymap.proto
+
+SomeType:
+	$(HPROTOC) --proto_path=.. some_type.proto
+
+clean:
+	rm -rf encode_map decode_map Mymap Mymap.hs *.{hi,o} Some_type Some_type.hs
+
+.PHONY: clean test

--- a/hprotoc/test/map-2/hs/decode_map.hs
+++ b/hprotoc/test/map-2/hs/decode_map.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+import qualified Data.ByteString.Lazy.Char8       as BL8
+import           Text.ProtocolBuffers.WireMessage
+import           Mymap.Result (Result(..))
+import           System.IO (stdin)
+
+main :: IO ()
+main = do
+    msg :: Either String (Result, BL8.ByteString)
+        <- messageGet <$> BL8.hGetContents stdin
+    case msg of
+        Left err -> fail err
+        Right (x, _)  -> print x

--- a/hprotoc/test/map-2/hs/encode_map.hs
+++ b/hprotoc/test/map-2/hs/encode_map.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE OverloadedStrings, OverloadedLists #-}
+import qualified Data.ByteString.Lazy.Char8       as BL8
+import           Text.ProtocolBuffers.Header      (Utf8(..))
+import           Text.ProtocolBuffers.WireMessage
+import           Some_type.SomeType               (SomeType(..))
+import           Mymap.Result                     (Result(..))
+import           System.IO                        (stdout)
+
+main :: IO ()
+main =
+    BL8.hPutStr stdout $ messagePut $
+        Result {
+            values =
+                [ (Utf8 "test"  , SomeType (Utf8 "x") (Utf8 "x")),
+                  (Utf8 "test_2", SomeType (Utf8 "y") (Utf8 "y")),
+                  (Utf8 "test_2", SomeType (Utf8 "z") (Utf8 "z"))
+                ]
+        }

--- a/hprotoc/test/map-2/mymap.proto
+++ b/hprotoc/test/map-2/mymap.proto
@@ -1,0 +1,7 @@
+syntax = "proto2";
+
+import "some_type.proto";
+
+message Result {
+    map<string, some_type.SomeType> values = 1;
+}

--- a/hprotoc/test/map-2/some_type.proto
+++ b/hprotoc/test/map-2/some_type.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+package some_type;
+
+message SomeType {
+    required string fieldOne = 1;
+    required string fieldTwo = 2;
+}

--- a/hprotoc/test/map-3/Makefile
+++ b/hprotoc/test/map-3/Makefile
@@ -1,0 +1,16 @@
+test: hs/encode_map hs/decode_map
+	@echo "\nHS -> HS\n" && \
+	./hs/encode_map | ./hs/decode_map && \
+	echo "\nHS -> RAW\n" && \
+	./hs/encode_map | protoc --decode_raw
+
+hs/encode_map: hs/encode_map.hs
+	cd hs && make encode_map
+
+hs/decode_map: hs/decode_map.hs
+	cd hs && make decode_map
+
+clean:
+	cd hs; make clean; cd ..;
+
+.PHONY: clean

--- a/hprotoc/test/map-3/hs/Makefile
+++ b/hprotoc/test/map-3/hs/Makefile
@@ -1,0 +1,23 @@
+GHC=stack exec ghc --
+
+HPROTOC=stack exec hprotoc --
+
+test: encode_map decode_map
+	./encode_map | ./decode_map
+
+decode_map: Mymap decode_map.hs
+	${GHC} --make -O1 decode_map.hs
+
+encode_map: Mymap MapPackage encode_map.hs
+	${GHC} --make -O1 encode_map.hs
+
+Mymap:
+	${HPROTOC} --proto_path=.. mymap.proto
+
+MapPackage:
+	$(HPROTOC) --proto_path=.. mapPackage.proto
+
+clean:
+	rm -rf encode_map decode_map Mymap Mymap.hs MapPackage MapPackage.hs *.{hi,o} tags
+
+.PHONY: clean test

--- a/hprotoc/test/map-3/hs/decode_map.hs
+++ b/hprotoc/test/map-3/hs/decode_map.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+import qualified Data.ByteString.Lazy.Char8       as BL8
+import           Text.ProtocolBuffers.WireMessage
+import           Mymap.Result (Result(..))
+import           System.IO (stdin)
+
+main :: IO ()
+main = do
+    msg :: Either String (Result, BL8.ByteString)
+        <- messageGet <$> BL8.hGetContents stdin
+    case msg of
+        Left err -> fail err
+        Right (x, _)  -> print x

--- a/hprotoc/test/map-3/hs/encode_map.hs
+++ b/hprotoc/test/map-3/hs/encode_map.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings, OverloadedLists #-}
+import qualified Data.ByteString.Lazy.Char8       as BL8
+import           Text.ProtocolBuffers.Header      (Utf8(..))
+import           Text.ProtocolBuffers.WireMessage
+import           MapPackage.WithMap               (WithMap(..))
+import           MapPackage.Value_type
+import           Mymap.Result                     (Result(..))
+import           System.IO                        (stdout)
+import           GHC.Int
+
+main :: IO ()
+main =
+    BL8.hPutStr stdout $ messagePut $
+        Result {
+            fullOfMaps = WithMap {
+                another_map_field = [(1::Int32, 2::Int32), (3, 4)],
+                map_field =
+                    [ (Utf8 "test"  , Value_type (Utf8 "x")),
+                      (Utf8 "test_2", Value_type (Utf8 "y"))
+                      -- (Utf8 "test_2", Value_type (Utf8 "z"))
+                    ]
+            }
+        }

--- a/hprotoc/test/map-3/mapPackage.proto
+++ b/hprotoc/test/map-3/mapPackage.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+package mapPackage;
+
+message value_type {
+    required string content = 1;
+}
+
+message WithMap {
+    map<string, value_type> map_field = 1;
+    map<int32, int32> another_map_field = 2;
+}

--- a/hprotoc/test/map-3/mymap.proto
+++ b/hprotoc/test/map-3/mymap.proto
@@ -1,0 +1,7 @@
+syntax = "proto2";
+
+import "mapPackage.proto";
+
+message Result {
+    required mapPackage.WithMap fullOfMaps = 1;
+}

--- a/hprotoc/test/map/Makefile
+++ b/hprotoc/test/map/Makefile
@@ -1,0 +1,24 @@
+test: hs/encode_map hs/decode_map cpp/encode_map cpp/decode_map
+	echo "\nHS -> HS\n" && \
+	./hs/encode_map | ./hs/decode_map && \
+	echo "\nHS -> CPP\n" && \
+	./hs/encode_map | ./cpp/decode_map && \
+	echo "\nCPP -> HS\n" && \
+	./cpp/encode_map | ./hs/decode_map
+
+hs/encode_map: hs/encode_map.hs
+	cd hs && make encode_map
+
+hs/decode_map: hs/decode_map.hs
+	cd hs && make decode_map
+
+cpp/encode_map: cpp/encode_map.cc
+	cd cpp && make encode_map
+
+cpp/decode_map: cpp/decode_map.cc
+	cd cpp && make decode_map
+
+clean:
+	cd hs; make clean; cd ..; cd cpp; make clean
+
+.PHONY: clean

--- a/hprotoc/test/map/cpp/Makefile
+++ b/hprotoc/test/map/cpp/Makefile
@@ -1,0 +1,16 @@
+decode_map: mymap.pb.o decode_map.o
+	g++ -std=c++11 -o decode_map decode_map.o mymap.pb.o `pkg-config --libs protobuf`
+
+mymap.pb.cc: ../mymap.proto
+	protoc --proto_path=.. --cpp_out=. ../mymap.proto
+
+decode_map.o: decode_map.cc
+	g++ -std=c++11 -c decode_map.cc `pkg-config --cflags protobuf`
+
+mymap.pb.o: mymap.pb.cc
+	g++ -std=c++11 -c mymap.pb.cc `pkg-config --cflags protobuf`
+
+clean:
+	rm decode_map decode_map.o mymap.pb.{cc,h,o}
+
+.PHONY: clean

--- a/hprotoc/test/map/cpp/Makefile
+++ b/hprotoc/test/map/cpp/Makefile
@@ -1,3 +1,12 @@
+test: encode_map decode_map
+	./encode_map | ./decode_map
+
+encode_map: mymap.pb.o encode_map.o
+	g++ -std=c++11 -o encode_map encode_map.o mymap.pb.o `pkg-config --libs protobuf`
+
+encode_map.o: encode_map.cc
+	g++ -std=c++11 -c encode_map.cc `pkg-config --cflags protobuf`
+
 decode_map: mymap.pb.o decode_map.o
 	g++ -std=c++11 -o decode_map decode_map.o mymap.pb.o `pkg-config --libs protobuf`
 
@@ -11,6 +20,6 @@ mymap.pb.o: mymap.pb.cc
 	g++ -std=c++11 -c mymap.pb.cc `pkg-config --cflags protobuf`
 
 clean:
-	rm decode_map decode_map.o mymap.pb.{cc,h,o}
+	rm -rf decode_map decode_map.o encode_map encode_map.o mymap.pb.{cc,h,o}
 
 .PHONY: clean

--- a/hprotoc/test/map/cpp/decode_map.cc
+++ b/hprotoc/test/map/cpp/decode_map.cc
@@ -1,0 +1,53 @@
+#include <fcntl.h>
+#include <iostream>
+#include <fstream>
+#include <streambuf>
+#include <string>
+
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include "mymap.pb.h"
+
+using namespace std;
+
+int main()
+{
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  char filename[] = "mymap.output";
+
+  WithMap msg;
+
+  fstream input(filename, ios::in | ios::binary);
+  msg.ParseFromIstream(&input);
+
+  string str;
+  google::protobuf::TextFormat::PrintToString(msg, &str);
+  cout << str << endl;
+
+  cout << "map_field_size: "
+       << msg.map_field_size()
+       << endl;
+
+  for(auto& kv: msg.map_field())
+      cout << "key="
+           << kv.first
+           << "\t"
+           << "value="
+           << kv.second.content()
+           << endl;
+
+  cout << endl;
+
+  cout << "another_map_field_size: "
+       << msg.another_map_field_size()
+       << endl;
+
+  for(auto& kv: msg.another_map_field())
+      cout << "key="
+           << kv.first
+           << "\t"
+           << "value="
+           << kv.second
+           << endl;
+}

--- a/hprotoc/test/map/cpp/decode_map.cc
+++ b/hprotoc/test/map/cpp/decode_map.cc
@@ -14,39 +14,36 @@ int main()
 {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  char filename[] = "mymap.output";
-
   WithMap msg;
 
-  fstream input(filename, ios::in | ios::binary);
-  msg.ParseFromIstream(&input);
+  msg.ParseFromIstream(&std::cin);
 
   string str;
   google::protobuf::TextFormat::PrintToString(msg, &str);
   cout << str << endl;
 
-  cout << "map_field_size: "
+  cout << "map_field_size(): "
        << msg.map_field_size()
        << endl;
 
   for(auto& kv: msg.map_field())
       cout << "key="
            << kv.first
-           << "\t"
+           << ", "
            << "value="
            << kv.second.content()
            << endl;
 
   cout << endl;
 
-  cout << "another_map_field_size: "
+  cout << "another_map_field_size(): "
        << msg.another_map_field_size()
        << endl;
 
   for(auto& kv: msg.another_map_field())
       cout << "key="
            << kv.first
-           << "\t"
+           << ", "
            << "value="
            << kv.second
            << endl;

--- a/hprotoc/test/map/cpp/encode_map.cc
+++ b/hprotoc/test/map/cpp/encode_map.cc
@@ -1,0 +1,28 @@
+#include <fcntl.h>
+#include <iostream>
+#include <fstream>
+#include <streambuf>
+#include <string>
+#include <map>
+
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include "mymap.pb.h"
+
+using namespace std;
+
+int main()
+{
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  WithMap msg;
+  auto* maf = msg.mutable_another_map_field();
+  for(auto& x: {1,2,3,4})
+      maf->insert({x,x});
+  auto* mf = msg.mutable_map_field();
+  auto vt = value_type();
+  vt.set_content("World!");
+  mf->insert({"Hello", vt});
+  msg.SerializeToOstream(&std::cout);
+}
+

--- a/hprotoc/test/map/hs/Makefile
+++ b/hprotoc/test/map/hs/Makefile
@@ -1,0 +1,10 @@
+encode_map: Mymap
+	stack exec ghc -- --make -O1 encode_map.hs
+
+Mymap:
+	stack exec hprotoc -- --proto_path=.. mymap.proto
+
+clean:
+	rm -rf encode_map Mymap Mymap.hs *.{hi,o}
+
+.PHONY: clean

--- a/hprotoc/test/map/hs/Makefile
+++ b/hprotoc/test/map/hs/Makefile
@@ -1,10 +1,20 @@
-encode_map: Mymap
-	stack exec ghc -- --make -O1 encode_map.hs
+GHC=stack exec ghc --
+
+HPROTOC=stack exec hprotoc --
+
+test: encode_map decode_map
+	./encode_map | ./decode_map
+
+decode_map: Mymap decode_map.hs
+	${GHC} --make -O1 decode_map.hs
+
+encode_map: Mymap encode_map.hs
+	${GHC} --make -O1 encode_map.hs
 
 Mymap:
-	stack exec hprotoc -- --proto_path=.. mymap.proto
+	${HPROTOC} --proto_path=.. mymap.proto
 
 clean:
-	rm -rf encode_map Mymap Mymap.hs *.{hi,o}
+	rm -rf decode_map encode_map Mymap Mymap.hs *.{hi,o}
 
-.PHONY: clean
+.PHONY: clean test

--- a/hprotoc/test/map/hs/decode_map.hs
+++ b/hprotoc/test/map/hs/decode_map.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+import qualified Data.ByteString.Lazy.Char8       as BL8
+import           Text.ProtocolBuffers.WireMessage
+import           Mymap.WithMap (WithMap)
+import           System.IO (stdin)
+
+main :: IO ()
+main = do
+    msg :: Either String (WithMap, BL8.ByteString)
+        <- messageGet <$> BL8.hGetContents stdin
+    case msg of
+        Left err -> fail err
+        Right (x, _)  -> print x

--- a/hprotoc/test/map/hs/encode_map.hs
+++ b/hprotoc/test/map/hs/encode_map.hs
@@ -1,32 +1,23 @@
-{-# LANGUAGE OverloadedStrings #-}
-import qualified Data.ByteString.Lazy.Char8 as LB
-import qualified Data.Sequence as Seq
-import System.Environment
-import System.IO
-import qualified Text.ProtocolBuffers.Header as P'
---
-import Text.ProtocolBuffers.Basic
-import Text.ProtocolBuffers.Header
-import Text.ProtocolBuffers.TextMessage
-import Text.ProtocolBuffers.WireMessage
---
-import Mymap
-import Mymap.Value_type
-import Mymap.WithMap (WithMap(..))
-import Mymap.WithMap.Map_field_Entry (Map_field_Entry(..))
-import qualified Mymap.WithMap.Another_map_field_Entry as X (Another_map_field_Entry(..))
---
+{-# LANGUAGE OverloadedStrings, OverloadedLists #-}
+import qualified Data.ByteString.Lazy.Char8       as BL8
+import           Text.ProtocolBuffers.Header      (Utf8(..))
+import           Text.ProtocolBuffers.WireMessage
+import           Mymap.Value_type
+import           Mymap.WithMap                    (WithMap(..))
+import           System.IO                        (stdout)
 
 main :: IO ()
-main = LB.writeFile "mymap.output" $ messagePut $
-    WithMap {
-        map_field =
-            Seq.fromList [
-                Map_field_Entry {key = P'.Utf8 "test"  , value = Value_type $ P'.Utf8 "x"},
-                Map_field_Entry {key = P'.Utf8 "test_2", value = Value_type $ P'.Utf8 "y"},
-                Map_field_Entry {key = P'.Utf8 "test_2", value = Value_type $ P'.Utf8 "z"}
-            ],
-        another_map_field = Seq.fromList [
-                X.Another_map_field_Entry {X.key=1, X.value=1}
-            ]
-    }
+main =
+    BL8.hPutStr stdout $ messagePut $
+        WithMap {
+            map_field =
+                [ (Utf8 "test"  , Value_type (Utf8 "x")),
+                  (Utf8 "test_2", Value_type (Utf8 "y")),
+                  (Utf8 "test_2", Value_type (Utf8 "z"))
+                ],
+            another_map_field =
+                [ (1, 1),
+                  (2, 2),
+                  (3, 3)
+                ]
+        }

--- a/hprotoc/test/map/hs/encode_map.hs
+++ b/hprotoc/test/map/hs/encode_map.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+import qualified Data.ByteString.Lazy.Char8 as LB
+import qualified Data.Sequence as Seq
+import System.Environment
+import System.IO
+import qualified Text.ProtocolBuffers.Header as P'
+--
+import Text.ProtocolBuffers.Basic
+import Text.ProtocolBuffers.Header
+import Text.ProtocolBuffers.TextMessage
+import Text.ProtocolBuffers.WireMessage
+--
+import Mymap
+import Mymap.Value_type
+import Mymap.WithMap (WithMap(..))
+import Mymap.WithMap.Map_field_Entry (Map_field_Entry(..))
+import qualified Mymap.WithMap.Another_map_field_Entry as X (Another_map_field_Entry(..))
+--
+
+main :: IO ()
+main = LB.writeFile "mymap.output" $ messagePut $
+    WithMap {
+        map_field =
+            Seq.fromList [
+                Map_field_Entry {key = P'.Utf8 "test"  , value = Value_type $ P'.Utf8 "x"},
+                Map_field_Entry {key = P'.Utf8 "test_2", value = Value_type $ P'.Utf8 "y"},
+                Map_field_Entry {key = P'.Utf8 "test_2", value = Value_type $ P'.Utf8 "z"}
+            ],
+        another_map_field = Seq.fromList [
+                X.Another_map_field_Entry {X.key=1, X.value=1}
+            ]
+    }

--- a/hprotoc/test/map/mymap.proto
+++ b/hprotoc/test/map/mymap.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+message value_type {
+    required string content = 1;
+}
+
+message WithMap {
+    map<string, value_type> map_field = 1;
+    map<int32, int32> another_map_field = 2;
+}

--- a/hprotoc/test/map/run.sh
+++ b/hprotoc/test/map/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cd hs/ && make && cd ..
+cd cpp/ && make && cd ..
+./hs/encode_map && ./cpp/decode_map
+rm mymap.output
+cd cpp/ && make clean && cd ..
+cd hs/ && make clean && cd ..

--- a/hprotoc/test/map/run.sh
+++ b/hprotoc/test/map/run.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-cd hs/ && make && cd ..
-cd cpp/ && make && cd ..
-./hs/encode_map && ./cpp/decode_map
-rm mymap.output
-cd cpp/ && make clean && cd ..
-cd hs/ && make clean && cd ..


### PR DESCRIPTION
Given a `.proto` file:

```
syntax = "proto2";

message value_type {
    required string content = 1;
}

message WithMap {
    map<string, value_type> map_field = 1;
    map<int32, int32> another_map_field = 2;
}
```

Generate the following Haskell datatype:

```
data WithMap = WithMap{map_field :: P'.Map (P'.Utf8) (Mymap.Value_type), another_map_field :: P'.Map (P'.Int32) (P'.Int32)}
             deriving (Prelude'.Show, Prelude'.Eq, Prelude'.Ord, Prelude'.Typeable, Prelude'.Data)
```

Each `map<k,v>` field is represented by a `Sequence` of `_Entry` values:

```
data Map_field_Entry = Map_field_Entry{key :: !(P'.Utf8), value :: !(Mymap.Value_type)}
                     deriving (Prelude'.Show, Prelude'.Eq, Prelude'.Ord, Prelude'.Typeable, Prelude'.Data)
```

Conversion from `Sequence` to map happen during (de-)serialization. For example:

```
... P'.wirePutRep 10 11 (Mymap.WithMap.map_field_EntryToSeq x'1) ...
```
