### PR TITLE
Moved printable bytestrings to use decimal escapes

### DIFF
--- a/Text/ProtocolBuffers/TextMessage.hs
+++ b/Text/ProtocolBuffers/TextMessage.hs
@@ -55,7 +55,7 @@ tellShow :: Show a => String -> a -> Output
 tellShow name v = tells $ name ++ ": " ++ show v
 
 tellStr :: String -> ByteString -> Output
-tellStr name s = tells $ name ++ ": \"" ++ dumpOctal s ++ "\""
+tellStr name s = tells $ name ++ ": \"" ++ dumpDecimal s ++ "\""
 
 tellSubMessage :: TextMsg a => String -> a -> Output
 tellSubMessage name m = do
@@ -65,13 +65,13 @@ tellSubMessage name m = do
     where
     indent = censor (fmap (\(!n, s) -> (n + 1, s)))
 
-dumpOctal :: ByteString -> String
-dumpOctal = C8.foldr escape []
+dumpDecimal :: ByteString -> String
+dumpDecimal = C8.foldr escape []
     where
     escape '\n' str = "\\n" ++ str
     escape '\"' str = "\\\"" ++ str
     escape c str | isAscii c && isPrint c = c : str
-    escape c str = printf "\\%03o" c ++ str
+    escape c str = printf "\\%03d" c ++ str
 
 instance TextType Int32 where
     tellT = tellShow


### PR DESCRIPTION
It's not clear why octal represenation was used previously and
actually that conversion was not reversible because of missing "o" in
the resulting escapes. Decimal escapes look to be more usable and
also compatible with the current parsing code
Fixes #24 