### PR TITLE
Attempt fix for "Not in scope" errors

### DIFF
--- a/hprotoc/Text/ProtocolBuffers/ProtoCompile/Gen.hs
+++ b/hprotoc/Text/ProtocolBuffers/ProtoCompile/Gen.hs
@@ -30,6 +30,7 @@ import Data.List(sortBy,foldl',foldl1',group,sort,union)
 import Data.Function(on)
 import Language.Haskell.Exts.Pretty(prettyPrint)
 import Language.Haskell.Exts.Syntax hiding (Int,String)
+import Language.Haskell.Exts.SrcLoc
 import Language.Haskell.Exts.Syntax as Hse
 import Data.Char(isLower,isUpper)
 import qualified Data.Map as M

--- a/hprotoc/hprotoc.cabal
+++ b/hprotoc/hprotoc.cabal
@@ -35,7 +35,7 @@ Executable hprotoc
                    containers,
                    directory >= 1.0.0.1,
                    filepath >= 1.1.0.0,
-                   haskell-src-exts >= 1.16.0,
+                   haskell-src-exts >= 1.16.0 && <= 1.17.1,
                    mtl,
                    parsec,
                    utf8-string


### PR DESCRIPTION
```
Text/ProtocolBuffers/ProtoCompile/Gen.hs:77:8:
    Not in scope: type constructor or class ‘SrcLoc’

Text/ProtocolBuffers/ProtoCompile/Gen.hs:78:7:
    Not in scope: data constructor ‘SrcLoc’

Text/ProtocolBuffers/ProtoCompile/Gen.hs:417:19:
    Not in scope: data constructor ‘EThingAll’
    Perhaps you meant ‘IThingAll’ (imported from Language.Haskell.Exts.Syntax)

Text/ProtocolBuffers/ProtoCompile/Gen.hs:699:68:
    Not in scope: data constructor ‘EThingAll’
    Perhaps you meant ‘IThingAll’ (imported from Language.Haskell.Exts.Syntax)
Failed to install hprotoc-2.4.0
```