### PR TITLE
make parser float support natural or float data format

### DIFF
--- a/Text/ProtocolBuffers/TextMessage.hs
+++ b/Text/ProtocolBuffers/TextMessage.hs
@@ -158,7 +158,7 @@ integer :: (Integral a, Stream s Identity Char) => Parsec s () a
 integer = fromIntegral <$> T.integer lexer
 
 float :: Stream s Identity Char => Parsec s () Double
-float = T.float lexer
+float = either realToFrac id <$> T.naturalOrFloat lexer
 
 stringLiteral :: Stream s Identity Char => Parsec s () String
 stringLiteral = T.stringLiteral lexer


### PR DESCRIPTION
make parser `float` support natural or float data format

for example,

```
   double price = 1;
```
could be `price: 20.0` or `price: 20` in text message.

The current version can't consume the latter.
This change is to make parser be able to handle these 2 formats.