### PR TITLE
restrict haskell-src-exts version to under 1.18

### DIFF
--- a/hprotoc/hprotoc.cabal
+++ b/hprotoc/hprotoc.cabal
@@ -35,7 +35,7 @@ Executable hprotoc
                    containers,
                    directory >= 1.0.0.1,
                    filepath >= 1.1.0.0,
-                   haskell-src-exts >= 1.16.0,
+                   haskell-src-exts >= 1.16.0 && < 1.18,
                    mtl,
                    parsec,
                    utf8-string


### PR DESCRIPTION
I was able to do `stack build hprotoc` without any errors. Other than that, I am not sure how to verify the correctness of this change.

This PR fixes #45.