### PR TITLE
Allow decimal places at the end of line

### DIFF
--- a/hprotoc/Text/ProtocolBuffers/ProtoCompile/Lexer.x
+++ b/hprotoc/Text/ProtocolBuffers/ProtoCompile/Lexer.x
@@ -25,7 +25,7 @@ $d = [0-9]
 
 @ident1 = [A-Za-z_][A-Za-z0-9_]*
 @ident = [\.]?@ident1([\.]@ident1)*
-@notChar = [^A-Za-z0-9_]
+@notChar = [^A-Za-z0-9_] | \n
 
 @hexEscape = \\[Xx][A-Fa-f0-9]{1,2}
 @octEscape = \\0?[0-7]{1,3}


### PR DESCRIPTION
`hprotoc` couldn't parse `realtime-bidding.proto` at https://developers.google.com/ad-exchange/rtb/data .

```
$ stack exec hprotoc -- -d /tmp/mytest/ realtime_bidding.proto
Loading filepath: "/private/tmp/protocol-buffers/realtime_bidding.proto"
hprotoc: user error (Parsing proto:
"/private/tmp/protocol-buffers/realtime_bidding.proto"
has failed with message
(line 7, column 0):
The error message from the nested subParser was:
  (line 398, column 0):
  The error message from the nested subParser was:
    (line 457, column 0):
    unexpected L_Error 457 "Lexical error (in Text.ProtocolBuffers.Lexer): decimal followed by invalid character, at character 20473 line 457 column 52."
    expecting field number (from 0 to 2^29-1 and not in 19000 to 19999)

    The next 10 tokens were [L 398 '{',L_Name 400 "enum",L_Name 400 "Placement",L 400 '{',L_Name 401 "UNKNOWN_PLACEMENT",L 401 '=',L_Integer 401 0,L 401 ';',L_Name 406 "INSTREAM",L 406 '=']

  The next 10 tokens were [L 7 '{',L_Name 9 "required",L_Name 9 "bytes",L_Name 9 "id",L 9 '=',L_Integer 9 2,L 9 ';',L_Name 17 "optional",L_Name 17 "bytes",L_Name 17 "ip"]

)
```

This is caused by following lines of protobuf.

```
    optional VideoPlaybackMethod playback_method = 14
        [default = METHOD_UNKNOWN];
```

The reason is that the `[^...]` grammar does not include `\n` . This PR solves the problem.
