### PR TITLE
Suppress all warnings in auto-generated files

### DIFF
--- a/hprotoc/Text/ProtocolBuffers/ProtoCompile/Gen.hs
+++ b/hprotoc/Text/ProtocolBuffers/ProtoCompile/Gen.hs
@@ -311,7 +311,7 @@ modulePragmas templateHaskell =
   [ LanguagePragma () (map (Ident ()) $
       thPragma ++ ["BangPatterns","DeriveDataTypeable","DeriveGeneric","FlexibleInstances","MultiParamTypeClasses","OverloadedStrings"]
     )
-  , OptionsPragma () (Just GHC) " -fno-warn-unused-imports "
+  , OptionsPragma () (Just GHC) " -w "
   ]
   where thPragma | templateHaskell = ["TemplateHaskell"]
                  | otherwise       = []


### PR DESCRIPTION
Rather than try to play whack-a-mole with GHC warnings, use -w to suppress all warnings in auto-generated files.

Fixes #83 