### PR TITLE
Stack resolver and Travis CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,42 @@
-language: c
 sudo: false
+dist: bionic
+language: generic
 
 cache:
   directories:
   - $HOME/.stack
+  - $HOME/.local/bin
 
 before_install:
   # stack
   - mkdir -p ~/.local/bin
   - mkdir -p ~/tmp
+  - travis_retry eval $"sudo apt-get update ; sleep 10"
+  - travis_retry eval $"sudo apt-get install --yes libgmp-dev haskell-stack ; sleep 10"
+  - if [ ! -d "$DIR" ]; then mkdir -p ~/.local/bin; fi
+  - travis_retry eval $"stack upgrade --binary-only ; sleep 10"
   - export PATH=~/.local/bin:$PATH
-  - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.1/stack-1.9.1-linux-x86_64.tar.gz | tar xz -C ~/tmp
-  - mv ~/tmp/stack-1.9.1-linux-x86_64/stack ~/.local/bin/
+  - hash -r
+  - stack --version
 
 matrix:
   include:
     - env: GHCVER=8.0.2 STACK_YAML=stack-8.0.2.yaml
       addons: {apt: {packages: [ghc-8.0.2],sources: [hvr-ghc]}}
-    - env: GHCVER=8.2.1 STACK_YAML=stack-8.2.1.yaml
-      addons: {apt: {packages: [ghc-8.2.1],sources: [hvr-ghc]}}
+    - env: GHCVER=8.2.2 STACK_YAML=stack-8.2.2.yaml
+      addons: {apt: {packages: [ghc-8.2.2],sources: [hvr-ghc]}}
     - env: GHCVER=8.4.2 STACK_YAML=stack-8.4.2.yaml
       addons: {apt: {packages: [ghc-8.4.2],sources: [hvr-ghc]}}
     - env: GHCVER=8.6.2 STACK_YAML=stack-8.6.2.yaml
       addons: {apt: {packages: [ghc-8.6.2],sources: [hvr-ghc]}}
-    - env: GHCVER=8.8.1 STACK_YAML=stack-8.8.1.yaml
-      addons: {apt: {packages: [ghc-8.8.1],sources: [hvr-ghc]}}
+    - env: GHCVER=8.8.4 STACK_YAML=stack-8.8.4.yaml
+      addons: {apt: {packages: [ghc-8.8.4],sources: [hvr-ghc]}}
 
 install:
   - stack --no-terminal --skip-ghc-check setup
   - stack --no-terminal --skip-ghc-check install happy alex
 
 script:
+  - rm -f stack.yaml
+  - cp -f $STACK_YAML stack.yaml
   - make test

--- a/protocol-buffers.cabal
+++ b/protocol-buffers.cabal
@@ -15,7 +15,7 @@ category:       Text
 extra-source-files: TODO
                     README.md
                     Changes
-Tested-With: GHC == 8.0.2, GHC == 8.2.1, GHC == 8.4.2, GHC == 8.6.2
+Tested-With: GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.2, GHC == 8.6.2, GHC == 8.8.4
 source-repository head
   type: git
   location: git://github.com/k-bx/protocol-buffers.git

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -1,7 +1,0 @@
-packages:
-- '.'
-- descriptor/
-- hprotoc/
-- protobuf-test-suite/
-resolver: nightly-2017-10-23
-extra-deps: []

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -3,5 +3,5 @@ packages:
 - descriptor/
 - hprotoc/
 - protobuf-test-suite/
+resolver: lts-11.22
 extra-deps: []
-resolver: nightly-2019-11-21

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -1,0 +1,10 @@
+packages:
+- '.'
+- descriptor/
+- hprotoc/
+- protobuf-test-suite/
+
+extra-deps:
+- haskell-src-exts-1.22.0@sha256:f558923a9c8f57402c33a8cc871b934027a5c65414404c87239f6cbd7357d54e,4541
+
+resolver: lts-16.17

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,1 @@
-packages:
-- '.'
-- descriptor/
-- hprotoc/
-- protobuf-test-suite/
-extra-deps: []
-resolver: lts-12.2
+stack-8.8.4.yaml


### PR DESCRIPTION
Sets default Stack resolver to lts-16.17 / GHC 8.8.4

Includes some Travis CI config from https://github.com/google/codeworld/blob/master/.travis.yml