### PR TITLE
Use base16-bytestring >= 1.0.0.0 after 'decode' API change

### DIFF
--- a/Text/ProtocolBuffers/ProtoJSON.hs
+++ b/Text/ProtocolBuffers/ProtoJSON.hs
@@ -41,5 +41,5 @@ parseJSONByteString :: Value -> Parser ByteString
 parseJSONByteString = withObject "bytes" $ \o -> do
     t <- o .: "payload"
     case B16.decode (T.encodeUtf8 t) of
-      (bs, "") -> return (BL.fromStrict bs)
-      _ -> fail "Failed to parse base16."
+      Right bs -> return (BL.fromStrict bs)
+      Left err -> fail $ "Failed to parse base16: " <> err

--- a/protocol-buffers.cabal
+++ b/protocol-buffers.cabal
@@ -40,7 +40,7 @@ Library
   build-depends: base >= 4.9.0 && < 5,
                  aeson >= 1.1.0.0,
                  array,
-                 base16-bytestring,
+                 base16-bytestring >= 1.0.0.0,
                  text,
                  binary,
                  bytestring,


### PR DESCRIPTION
It would also be good to fixup the old versions to constrain `base16-bytestring < 1.0.0.0` via package revisions (I'm not sure who you talk to about that)