### PR TITLE
Allow newer haskell-src-exts and test for GHC-8.10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
       addons: {apt: {packages: [ghc-8.6.2],sources: [hvr-ghc]}}
     - env: GHCVER=8.8.4 STACK_YAML=stack-8.8.4.yaml
       addons: {apt: {packages: [ghc-8.8.4],sources: [hvr-ghc]}}
+    - env: GHCVER=8.10.2 STACK_YAML=stack-8.10.2.yaml
+      addons: {apt: {packages: [ghc-8.8.4],sources: [hvr-ghc]}}
 
 install:
   - stack --no-terminal --skip-ghc-check setup

--- a/hprotoc/hprotoc.cabal
+++ b/hprotoc/hprotoc.cabal
@@ -37,7 +37,7 @@ Executable hprotoc
                    containers,
                    directory >= 1.0.0.1,
                    filepath >= 1.1.0.0,
-                   haskell-src-exts >= 1.18 && < 1.23,
+                   haskell-src-exts >= 1.18 && < 1.24,
                    mtl,
                    parsec,
                    utf8-string
@@ -85,7 +85,7 @@ Library
                    containers,
                    directory >= 1.0.0.1,
                    filepath >= 1.1.0.0,
-                   haskell-src-exts >= 1.18 && < 1.23,
+                   haskell-src-exts >= 1.18 && < 1.24,
                    mtl,
                    parsec,
                    utf8-string

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -1,0 +1,7 @@
+packages:
+- '.'
+- descriptor/
+- hprotoc/
+- protobuf-test-suite/
+extra-deps: []
+resolver: nightly-2020-09-21


### PR DESCRIPTION
This should fail with https://github.com/k-bx/protocol-buffers/issues/91