### PR TITLE
Fix up a534ea to support older base16-bytestring again, via CPP

### DIFF
--- a/Text/ProtocolBuffers/ProtoJSON.hs
+++ b/Text/ProtocolBuffers/ProtoJSON.hs
@@ -41,5 +41,10 @@ parseJSONByteString :: Value -> Parser ByteString
 parseJSONByteString = withObject "bytes" $ \o -> do
     t <- o .: "payload"
     case B16.decode (T.encodeUtf8 t) of
+#    if MIN_VERSION_base16_bytestring(1,0,0)
       Right bs -> return (BL.fromStrict bs)
       Left err -> fail $ "Failed to parse base16: " <> err
+#    else
+      (bs, "") -> return (BL.fromStrict bs)
+      _ -> fail "Failed to parse base16."
+#    endif

--- a/protocol-buffers.cabal
+++ b/protocol-buffers.cabal
@@ -40,7 +40,7 @@ Library
   build-depends: base >= 4.9.0 && < 5,
                  aeson >= 1.1.0.0,
                  array,
-                 base16-bytestring >= 1.0.0.0,
+                 base16-bytestring,
                  text,
                  binary,
                  bytestring,


### PR DESCRIPTION
See: https://github.com/k-bx/protocol-buffers/pull/90#issuecomment-721072573