### PR TITLE
Fix Setup.hs because defaultUserHooks in Cabal is deprecated

### DIFF
--- a/hprotoc/Setup.hs
+++ b/hprotoc/Setup.hs
@@ -1,2 +1,2 @@
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMainWithHooks simpleUserHooks


### PR DESCRIPTION
This has already been fixed for the main package with
afbf55dc9f0fcaadedcfa048aa5b3b03a35ba7d0 (see #89), but unfortunately
forgotten for hprotoc.

Cabal > 3.0 has removed `defaultUserHooks` which is now an error. A lot
of package distributors build packages with Cabal. Therefore this is
desirable to fix.