### PR TITLE
fix: make it possible to compile a protobuf with oneof and extensions

### DIFF
--- a/protobuf-test-suite/proto/myoneof.proto
+++ b/protobuf-test-suite/proto/myoneof.proto
@@ -1,0 +1,7 @@
+message OneofWithExtension {
+    required string a = 1;
+    oneof b {
+        string c = 2;
+    }
+    extensions 100 to 9999;
+}


### PR DESCRIPTION
Hello.

Currently, `hprotoc` can't compile the `.proto` message containing `oneof` and `extensions` fields correctly, like these files.

* https://github.com/hiratara/protocol-buffers/blob/c128905834bdd3f26f52eb3c438272d0940cf432/protobuf-test-suite/proto/myoneof.proto
* https://github.com/InteractiveAdvertisingBureau/openrtb-proto-v2/blob/master/openrtb-core/src/main/protobuf/openrtb.proto

This PR fixes the issue.
