### PR TITLE
fix: allow to specify --json and --lenses at the same time

### DIFF
--- a/protobuf-test-suite/codegen.sh
+++ b/protobuf-test-suite/codegen.sh
@@ -3,11 +3,20 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROTO_PATH="$DIR/proto"
 PROTO_PREFIX="HSCodeGen"
+PROTO_LENSE_PREFIX="HSCodeGen.Lense"
 HASKELL_SRC_PATH="$DIR/src"
 
 stack exec hprotoc -- \
   --haskell_out=$HASKELL_SRC_PATH \
   --proto_path=$PROTO_PATH \
   --prefix=$PROTO_PREFIX \
+  --json \
+  --unknown_fields `find $PROTO_PATH -type f | egrep '\.proto$'`
+
+stack exec hprotoc -- \
+  --haskell_out=$HASKELL_SRC_PATH \
+  --proto_path=$PROTO_PATH \
+  --prefix=$PROTO_LENSE_PREFIX \
+  --lenses \
   --json \
   --unknown_fields `find $PROTO_PATH -type f | egrep '\.proto$'`

--- a/protobuf-test-suite/package.yaml
+++ b/protobuf-test-suite/package.yaml
@@ -6,6 +6,7 @@ library:
   dependencies:
     - base
     - filepath
+    - lens
     - process
     - protocol-buffers
     - protocol-buffers-descriptor


### PR DESCRIPTION
When I specify `--lenses` and `--json` simultaneously, I can't compile the generated files. This is because we don't consider that `--lenses` adds `"_"` to the field name.

This PR fixes the issue.
